### PR TITLE
Upgrade action to use Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@v3
-        name: Set Node.js 16.x
+        name: Set Node.js 20.x
         with:
-          node-version: 16.x
+          node-version: 20.x
       - uses: actions/checkout@v3
       - run: npm ci
       - run: npm run build
@@ -35,12 +35,12 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Set Node.js 16.x
-        uses: actions/setup-node@v3
+      - name: Set Node.js 20.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Install dependencies
         run: npm ci
@@ -57,7 +57,7 @@ jobs:
           fi
 
       # If dist/ was different than expected, upload the expected version as an artifact
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ failure() && steps.diff.conclusion == 'failure' }}
         with:
           name: dist

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Check licenses
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: npm ci
       - run: npm run licensed-check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
           

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.1.0
+
+- Upgrade action to use the Node 20 (Node 16 EOL)
+- Bump dependencies to the last versions (see [full changelog](https://github.com/ChristopheLav/appinsights-annotate/compare/v1...v1.1.0))
+
 ## v1.0.2
 
 - Bump @typescript-eslint/parser from 5.27.1 to 5.28.0 (#9)

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     description: 'Allows to treat error as warning to prevent worlflow failure. It is may not important in some cases if the annotation can not be created.'
     default: false
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: zap


### PR DESCRIPTION
Node 16 is End of Life and GitHub begin to display deprecation warnings.