### PR TITLE
Improved CodeQL configuration

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,6 +5,13 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.txt'
+      - 'dist/**'
+      - 'imgs/**'
+      - '.licenses/**'
+      - 'LICENSE'
   schedule:
     - cron: '33 3 * * 2'
 
@@ -36,6 +43,9 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
+        config: |
+          paths-ignore:
+            - 'dist/**'
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
- Exclude some directories to CodeQL workflow trigger to prevent too often run
- Exclude `dist` directory of the CodeQL analysis to prevent false positives 